### PR TITLE
Add version requirement for dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,3 +14,9 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 mousetrap_apple_jll = "7f2654e2-337a-59f5-9aed-6445982bfb16"
 mousetrap_linux_jll = "b6bb2801-a71f-530d-97b4-a6ed24b69d40"
 mousetrap_windows_jll = "1923bf96-b834-50bb-8499-88d15429481f"
+
+[compat]
+CxxWrap = "0.13.4"
+mousetrap_apple_jll = "0.1.0"
+mousetrap_linux_jll = "0.1.0"
+mousetrap_windows_jll = "0.1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ mousetrap_linux_jll = "b6bb2801-a71f-530d-97b4-a6ed24b69d40"
 mousetrap_windows_jll = "1923bf96-b834-50bb-8499-88d15429481f"
 
 [compat]
-CxxWrap = "0.13.4"
-mousetrap_apple_jll = "0.1.0"
-mousetrap_linux_jll = "0.1.0"
-mousetrap_windows_jll = "0.1.0"
+CxxWrap = "^0.13.4"
+mousetrap_apple_jll = "=0.1.0"
+mousetrap_linux_jll = "=0.1.0"
+mousetrap_windows_jll = "=0.1.0"

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Where all four packages need to be installed, regardless of the operating system
 
 Installation may take a long time. Once mousetrap is installed and precompilation is done, it can be loaded in only a few seconds during regular usage.
 
-> **Note**: On Windows, some `GLib` log messages regarding dbus connections and  may appear during testing. These do not indicate a problem, as long as at the end of the testing suite it says `mousetrap tests passed`.
+> **Note**: On Windows and Mac, some `GLib` log messages regarding dbus connections may appear during testing. These do not indicate a problem, as long as at the end of the testing suite it says `mousetrap tests passed`.
 
 ---
 


### PR DESCRIPTION
Limits the `_jll` dependency versions and introduces a compatibility requirement for `CxxWrap`, cf. #4