### PR TITLE
Add version requirement, remove deprecated features in preparation for 0.2 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "mousetrap"
 uuid = "5deeb4b9-6e04-4da7-8b7f-c77fb1eae65e"
 authors = ["C.Cords <mail@clemens-cords.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 BinaryBuilder = "12aac903-9f7c-5d81-afc2-d9565ea332ae"

--- a/Project.toml
+++ b/Project.toml
@@ -14,3 +14,9 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 mousetrap_apple_jll = "7f2654e2-337a-59f5-9aed-6445982bfb16"
 mousetrap_linux_jll = "b6bb2801-a71f-530d-97b4-a6ed24b69d40"
 mousetrap_windows_jll = "1923bf96-b834-50bb-8499-88d15429481f"
+
+[compat]
+CxxWrap = "0.3.14"
+mousetrap_apple_jll = "=0.1.0"
+mousetrap_linux_jll = "=0.1.0"
+mousetrap_windows_jll = "=0.1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ mousetrap_linux_jll = "b6bb2801-a71f-530d-97b4-a6ed24b69d40"
 mousetrap_windows_jll = "1923bf96-b834-50bb-8499-88d15429481f"
 
 [compat]
-CxxWrap = "0.3.14"
+CxxWrap = "0.13.4"
 mousetrap_apple_jll = "=0.1.0"
 mousetrap_linux_jll = "=0.1.0"
 mousetrap_windows_jll = "=0.1.0"


### PR DESCRIPTION
This PR is intended to future proof mousetrap v0.1.*, as v0.2 will create a breaking change by changing the name to `Mousetrap` (upper case).

Furthermore, the `StyleClass` feature from v0.1 was remove, as it will be replaced with the `StyleManager` interface that is currently in development.