### PR TITLE
migrate to 3.2

### DIFF
--- a/docs/src/01_manual/08_menus.md
+++ b/docs/src/01_manual/08_menus.md
@@ -260,7 +260,7 @@ The **top-level** menu is `root`. It is used as the argument for the constructor
 
 No direct child of `root` is an "action"-, "widget"-, "icon"- or "section"-type item. This is what is required for `MenuBar`. All top-level items have to be submenus.
 
-!!! Warning
+!!! warning
     Due to a bug in the backend, as of `v0.3.0`, a menu model used for a `MenuBar` **may not have a "widget"-type item in a submenu of a submenu**.
 
     This means we *can* add a widget to any submenu of `root`, but we may not add 
@@ -268,6 +268,27 @@ No direct child of `root` is an "action"-, "widget"-, "icon"- or "section"-type 
 
     This bug does not affect `PopoverMenu`, for whom we can put a widget at any 
     depth. `PopoverMenu` has no requirement as to the structure of its menu model, while `MenuBar` requires that all top-level items are submenus and that no submenu of a submenu may have a "widget"-type item.
+
+## Main Menu (macOS only)
+
+!!! compat
+    Features from this section are only available with Mousetrap `v0.3.1` or newer, and should only be used by applications targeting macOS. We can use `Sys.isapple` to verify the user's operating system.
+
+On macOS, applications are able to target the [**main menu**](https://support.apple.com/en-gb/guide/mac-help/mchlp1446/mac), which is the menubar at the very top of the screen (outside the Mousetrap window). This bar contains the Apple menu, as well as a native menubar with application-specific options. To bind a `Mousetrap.MenuModel` to this menubar, we use `set_menubar` on our `Application` instance:
+
+```julia
+main() do app::Application
+
+    model = MenuModel()
+    # fill model here
+    
+    if Sys.isapple()
+        set_menubar(app, model) # associate model with the Apple main menu
+    end
+end
+```
+
+Note that it may be necessary to call `set_menubar` again when the `MenuModel` is modified in order for the main menu to be updated.
 
 ---
 

--- a/docs/src/01_manual/10_theme_customization.md
+++ b/docs/src/01_manual/10_theme_customization.md
@@ -198,7 +198,7 @@ By default, the function used to map the elapsed duration of the `Animation` to 
 
 Mousetrap uses [Cascading Style Sheets (CSS)](https://developer.mozilla.org/en-US/docs/Web/CSS) to define the exact look of a widget. A UI theme is nothing more than a huge CSS file from which all widgets take information about how they should be rendered. 
 
-!!! Warning "CSS"
+!!! warning "CSS"
     The rest of this chapter will assume that readers are familiar with the basics of CSS. Readers are encouraged to consult [this documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference) for CSS-related questions.
 
 ## Applying CSS Properties to a Widget

--- a/src/Mousetrap.jl
+++ b/src/Mousetrap.jl
@@ -4132,7 +4132,7 @@ module Mousetrap
             @log_warning MOUSETRAP_DOMAIN "In ColumnView::push_back_rows: Attempting to push $(length(widgets)) widgets, but ColumnView only has $(get_n_columns(column_view)) columns"
         end
 
-        row_i = get_n_rows(column_view)
+        row_i = get_n_rows(column_view) + 1
         for i in 1:get_n_columns(column_view)
             column = get_column_at(column_view, i)
             set_widget_at!(column_view, column, row_i, widgets[i])

--- a/src/Mousetrap.jl
+++ b/src/Mousetrap.jl
@@ -3211,6 +3211,13 @@ module Mousetrap
 
     @add_signal_items_changed MenuModel
 
+    function set_menubar(app::Application, model::MenuModel)
+        if !Sys.isapple() 
+            log_warning(MOUSETRAP_DOMAIN, "In set_menubar: setting an application-wide menubar is only supported on macOS. Use `Sys.isapple()` to verify the users system before calling this function")
+        end
+        Mousetrap.detail.set_menubar(app._internal, model._internal)
+    end
+
     Base.show(io::IO, x::MenuModel) = show_aux(io, x)
 
 ###### menubar.jl
@@ -5573,4 +5580,18 @@ end # else MOUSETRAP_ENABLE_OPENGL_COMPONENT
         return out
     end
     @define_compound_widget_signals()
+
+###### internal.jl
+
+    function as_gobject_pointer(x::T) where T <: Union{SignalEmitter, Widget} :: Ptr{Cvoid}
+        return Mousetrap.detail.as_gobject(x._internal.cpp_object)
+    end
+
+    function as_internal_pointer(x::T) where T <: Union{SignalEmitter, Widget} ::Ptr{Cvoid}
+        return Mousetrap.detail.as_internal(x._internal.cpp_object)
+    end
+
+    function as_native_widget(x::Widget) 
+        return Mousetrap.detail.as_native_widget(Mousetrap.as_widget_pointer(x))
+    end
 end

--- a/src/Mousetrap.jl
+++ b/src/Mousetrap.jl
@@ -4085,6 +4085,17 @@ module Mousetrap
     @export_function ColumnViewColumn set_is_resizable! Cvoid Bool b
     @export_function ColumnViewColumn get_is_resizable Bool
 
+    function set_expand!(column::ColumnViewColumn, should_expand::Bool)
+        @ccall detail.GTK4_jll.libgtk4.gtk_column_view_column_set_expand(Mousetrap.as_internal_pointer(column)::Ptr{Cvoid}, should_expand::Bool)::Cvoid
+        return nothing
+    end
+    export set_expand!
+
+    function get_expand(column::ColumnViewColumn) ::Bool 
+        return @ccall detail.GTK4_jll.libgtk4.gtk_column_view_column_get_expand(Mousetrap.as_internal_pointer(column)::Ptr{Cvoid})::Bool
+    end
+    export get_expand
+
     @export_type ColumnView Widget
     @declare_native_widget ColumnView
 
@@ -5583,12 +5594,16 @@ end # else MOUSETRAP_ENABLE_OPENGL_COMPONENT
 
 ###### internal.jl
 
-    function as_gobject_pointer(x::T) where T <: Union{SignalEmitter, Widget} :: Ptr{Cvoid}
+    function as_gobject_pointer(x::T) where T <: Union{SignalEmitter, Widget} #::Ptr{Cvoid}
         return Mousetrap.detail.as_gobject(x._internal.cpp_object)
     end
 
-    function as_internal_pointer(x::T) where T <: Union{SignalEmitter, Widget} ::Ptr{Cvoid}
+    function as_internal_pointer(x::T) where T <: Union{SignalEmitter, Widget} #::Ptr{Cvoid}
         return Mousetrap.detail.as_internal(x._internal.cpp_object)
+    end
+
+    function as_internal_pointer(column::ColumnViewColumn) 
+        return @ccall detail.mousetrap_jll.mousetrap._ZNK9mousetrap10ColumnView6Column12get_internalEv(column._internal.cpp_object::Ptr{Cvoid})::Ptr{Cvoid}
     end
 
     function as_native_widget(x::Widget) 

--- a/src/Mousetrap.jl
+++ b/src/Mousetrap.jl
@@ -4160,7 +4160,7 @@ module Mousetrap
         row_i = 1
         for i in 1:get_n_columns(column_view)
             column = get_column_at(column_view, i)
-            set_widget_at!(column_view, column, from_julia_index(row_i), widgets[i])
+            set_widget_at!(column_view, column, row_i, widgets[i])
         end
     end
     export push_front_row!
@@ -4174,7 +4174,7 @@ module Mousetrap
         row_i = index
         for i in 1:get_n_columns(column_view)
             column = get_column_at(column_view, i)
-            set_widget!(column_view, column, row_i, widgets[i])
+            set_widget_at!(column_view, column, row_i, widgets[i])
         end
     end
     export push_front_row!

--- a/src/docgen/functions.jl
+++ b/src/docgen/functions.jl
@@ -1219,6 +1219,13 @@ get_end_child_shrinkable(::Paned) -> Bool
 Get whether the user can resize the end child such that its allocated area inside the `Paned` is smaller than the natural size of the child.
 """
 
+@document get_expand """
+```
+get_expand(::ColumnViewColumn) -> Bool
+```
+Get whether this column expands horizontally.
+"""
+
 @document get_expand_horizontally """
 ```
 get_expand_horizontally(::Widget) -> Bool
@@ -4179,6 +4186,13 @@ Set whether the user can resize the end child such that its allocated area insid
 set_expand!(::Widget, ::Bool) 
 ```
 Set whether the widget should expand along both the horizontal and vertical axis.
+
+---
+
+```
+set_expand!(::ColumnViewColumn, ::Bool)
+```
+Set whether the column should expand along the horizontal axis.
 """
 
 @document set_is_expanded! """

--- a/src/docgen/functions.jl
+++ b/src/docgen/functions.jl
@@ -427,6 +427,22 @@ Create a new image that is a horizontally and/or vertically mirrored.
 This function does not modify the original image.
 """
 
+@document as_gobject_pointer """
+```
+as_gobject_pointer(<: SignalEmitter) -> Ptr{Cvoid}
+as_gobject_pointer(<: Widget) -> Ptr{Cvoid}
+```
+Get the raw C pointer pointing to the native `GObject` in memory, for use with `ccall` and `Glib_jll`. Note that Mousetrap handles the lifetime of this object automatically, calling `g_object_ref` or `g_object_unref` on the pointer will cause memory leaks or segmentation faults.
+"""
+
+@document as_internal_pointer """
+```
+as_internal_pointer(<: SignalEmitter) -> Ptr{Cvoid}
+as_internal_pointer(<: Widget) -> Ptr{Cvoid}
+```
+Get the raw C pointer pointing to the Mousetrap C++ object, for use with `ccall` and `mousetrap_jll.mousetrap`.
+"""
+
 @document as_line! """
 ```
 as_line!(::Shape, a::Vector2f, b::Vector2f) 
@@ -446,6 +462,13 @@ Create a shape as a line strip. For points `{a1, a2, ..., an}`, this will be a s
 as_lines!(::Shape, points::Vector{Pair{Vector2f, Vector2f}}) 
 ```
 Create a shape as a set of unconnected lines, vertex positions in OpenGL coordinates.
+"""
+
+@document as_native_widget """
+```
+as_native_widget(<: Widget) -> Ptr{Cvoid}
+```
+Get the raw C pointer pointing to the native `GObject` in memory, for use with `ccall` and `GTK4_jll`. Note that Mousetrap handles the lifetime of this object automatically, calling `g_object_ref` or `g_object_unref` on the pointer will cause memory leaks or segmentation faults.
 """
 
 @document as_microseconds """
@@ -4688,6 +4711,16 @@ Attempt to maximize or unmaximize the window.
 set_message!(::AlertDialog, ::String)
 ```
 Set the main message of the dialog, this will be used as the dialogs title.
+"""
+
+@document set_menubar """
+```
+set_menubar(::Application, ::MenuModel)
+```
+Associate a menu model with the application-wide menubar. On macOS only, this will update the Apple main menu at the very top of the screen.
+
+This function will print a warning if called on a non-Apple machine. Use `Sys.isapple` to verify the users OS before calling this function.
+```
 """
 
 @document set_minimized! """

--- a/test/example.jl
+++ b/test/example.jl
@@ -1,6 +1,36 @@
 # File used for debugging and for dosc examples, why are you snooping through this file?
 using Mousetrap
 
+main() do app::Application
+    window = Window(app)
+
+    column_view = ColumnView()
+
+    row_index = push_back_column!(column_view, " ")
+    count_column = push_back_column!(column_view, "#")
+    name_column = push_back_column!(column_view, "Name")
+    weigt_column = push_back_column!(column_view, "Weight")
+    unit_column = push_back_column!(column_view, "Units")
+
+    # fill columns with example text
+    for i in 1:100
+        push_back_row!(column_view,
+            Label(string(i)),           # row index
+            Label(string(rand(0:99))),  # count
+            Label(rand(["Apple", "Orange", "Banana", "Kumquat", "Durian", "Mangosteen"])), # name
+            Label(string(rand(0:100))), # weight
+            Label(string(rand(["mg", "g", "kg", "ton"]))) # unit
+        )
+    end
+
+    scrolled_viewport = Viewport()
+    set_child!(scrolled_viewport, column_view)
+    set_child!(window, scrolled_viewport)
+    present!(window)
+end
+
+if false 
+
 add_css!("""
 @keyframes spin-animation {
     0%   { transform: rotate(0turn)   scale(1); }
@@ -658,3 +688,5 @@ end
 end # @static if
 
     =#
+
+end

--- a/test/example.jl
+++ b/test/example.jl
@@ -4,27 +4,37 @@ using Mousetrap
 main() do app::Application
     window = Window(app)
 
+    # create column view with columns
     column_view = ColumnView()
 
-    row_index = push_back_column!(column_view, " ")
+    row_index_column = push_back_column!(column_view, " ")
     count_column = push_back_column!(column_view, "#")
     name_column = push_back_column!(column_view, "Name")
-    weigt_column = push_back_column!(column_view, "Weight")
+    weight_column = push_back_column!(column_view, "Weight")
     unit_column = push_back_column!(column_view, "Units")
 
-    # fill columns with example text
+    set_expand!.((row_index, count_column, name_column, weight_column, unit_column), true)
+
+    # fill columns with text
     for i in 1:100
-        push_back_row!(column_view,
+        row = [
             Label(string(i)),           # row index
             Label(string(rand(0:99))),  # count
             Label(rand(["Apple", "Orange", "Banana", "Kumquat", "Durian", "Mangosteen"])), # name
             Label(string(rand(0:100))), # weight
             Label(string(rand(["mg", "g", "kg", "ton"]))) # unit
-        )
+        ]
+
+        set_horizontal_alignment!.(row, ALIGNMENT_START)
+        push_back_row!(column_view, row...)
     end
 
+    # create viewport, this will add a scrollbar
     scrolled_viewport = Viewport()
+    set_propagate_natural_width!(scrolled_viewport, true) # hides horizontal scrollbar
     set_child!(scrolled_viewport, column_view)
+
+    # show both in window
     set_child!(window, scrolled_viewport)
     present!(window)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2878,31 +2878,3 @@ main(Main.app_id) do app::Application
     close!(window)
     #quit!(app)
 end
-
-using Mousetrap
-main() do app
-    window = Window(app)
-
-    revealer = Revealer()
-    set_transition_type!(revealer, REVEALER_TRANSITION_TYPE_SLIDE_LEFT)
-
-    button = Button()
-    set_child!(button, Label("click me"))
-    connect_signal_clicked!(button) do self
-        set_is_revealed!(revealer, !get_is_revealed(revealer))
-    end
-
-    to_reveal = Label("REVEALED")
-    set_margin!(to_reveal, 10)
-    set_child!(revealer, to_reveal)
-    set_is_revealed!(revealer, false)
-    connect_signal_revealed!(revealer) do self
-        println("revealed")
-    end
-
-    box = Box(ORIENTATION_HORIZONTAL)
-    push_back!(box, button)
-    push_back!(box, revealer)
-    set_child!(window, box)
-    present!(window)
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1291,6 +1291,16 @@ function test_image_display(::Container)
     end
 end
 
+### INTERNAL
+
+function test_internal(x::Container)
+    @testset "Internal" begin
+        @test as_gobject_pointer(x) != C_NULL
+        @test as_internal_pointer(x) != C_NULL
+        @test as_native_widget(x) != C_NULL
+    end
+end
+
 ### KEY_FILE
 
 function test_key_file(::Container)
@@ -1565,6 +1575,10 @@ function test_menus(::Container)
     @testset "MenuModel" begin
         Base.show(devnull, root)
         @test items_changed_called[] == true
+
+        if Sys.isapple() 
+            set_menubar(app[], root)
+        end
     end
    
     @testset "MenuBar" begin
@@ -2822,6 +2836,7 @@ main(Main.app_id) do app::Application
         test_icon(container)
         test_image(container)
         test_image_display(container)
+        test_internal(container)
         test_key_file(container)
         test_label(container)
         test_level_bar(container)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -753,6 +753,10 @@ function test_column_view(::Container)
         set_expand!(column, true)
         @test get_expand(column) == true
 
+        push_back_row!(column_view, Label(""), Label(""), Label(""))
+        push_front_row!(column_view, Label(""), Label(""), Label(""))
+        insert_row_at!(column_view, 2, Label(""), Label(""), Label(""))
+
         @test get_title(column) == column_name
 
         new_title = "new title"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -749,6 +749,10 @@ function test_column_view(::Container)
         column_name = "column 02"
         column = insert_column_at!(column_view, 1, column_name)
 
+        @test get_expand(column) == false 
+        set_expand!(column, true)
+        @test get_expand(column) == true
+
         @test get_title(column) == column_name
 
         new_title = "new title"
@@ -1295,9 +1299,9 @@ end
 
 function test_internal(x::Container)
     @testset "Internal" begin
-        @test as_gobject_pointer(x) != C_NULL
-        @test as_internal_pointer(x) != C_NULL
-        @test as_native_widget(x) != C_NULL
+        @test Mousetrap.as_gobject_pointer(x) != C_NULL
+        @test Mousetrap.as_internal_pointer(x) != C_NULL
+        @test Mousetrap.as_native_widget(x) != C_NULL
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2874,3 +2874,31 @@ main(Main.app_id) do app::Application
     close!(window)
     #quit!(app)
 end
+
+using Mousetrap
+main() do app
+    window = Window(app)
+
+    revealer = Revealer()
+    set_transition_type!(revealer, REVEALER_TRANSITION_TYPE_SLIDE_LEFT)
+
+    button = Button()
+    set_child!(button, Label("click me"))
+    connect_signal_clicked!(button) do self
+        set_is_revealed!(revealer, !get_is_revealed(revealer))
+    end
+
+    to_reveal = Label("REVEALED")
+    set_margin!(to_reveal, 10)
+    set_child!(revealer, to_reveal)
+    set_is_revealed!(revealer, false)
+    connect_signal_revealed!(revealer) do self
+        println("revealed")
+    end
+
+    box = Box(ORIENTATION_HORIZONTAL)
+    push_back!(box, button)
+    push_back!(box, revealer)
+    set_child!(window, box)
+    present!(window)
+end


### PR DESCRIPTION
Adds `set_menubar`, which allows settings the main menu on macOS. Furthermore exposes the raw GTK4 / GLib / C++ Mousetrap pointers, to allow for interfacing with jll wrappers using `ccall`