### PR TITLE
Run CI on latest stable Julia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,7 @@ jobs:
           julia-version:
             - "1.7"
             - "1.9"
+            - "1"
           os:
             - ubuntu-latest
             - macos-latest


### PR DESCRIPTION
"1" currently expands to 1.10, but once 1.11, etc. are released, "1" will point to those instead.